### PR TITLE
fix: increase body size limit to 5mb and improve test coverage

### DIFF
--- a/event/src/app.ts
+++ b/event/src/app.ts
@@ -25,8 +25,8 @@ const router = new EventRouter(fftApiClient);
 const app: Express = express();
 
 // Define configurations
-app.use(bodyParser.json({ limit: '1mb' }));
-app.use(bodyParser.urlencoded({ limit: '1mb', extended: true }));
+app.use(bodyParser.json({ limit: '5mb' }));
+app.use(bodyParser.urlencoded({ limit: '5mb', extended: true }));
 app.disable('x-powered-by');
 
 // Define routes

--- a/event/src/order/testModels.ts
+++ b/event/src/order/testModels.ts
@@ -258,6 +258,58 @@ export function getTestOrderWithStore() {
   return mapTemplateToOrder(template);
 }
 
+export function getTestOrderWithBillingAddress(): CommercetoolsOrder {
+  return {
+    ...mapTemplateToOrder(commercetoolsOrderTemplate),
+    billingAddress: {
+      firstName: 'Bill',
+      lastName: 'Payer',
+      streetName: 'Invoice St',
+      streetNumber: '5',
+      postalCode: '80331',
+      city: 'Munich',
+      country: 'DE',
+    },
+  };
+}
+
+export function getTestOrderWithFullAddress(): CommercetoolsOrder {
+  return {
+    ...mapTemplateToOrder(commercetoolsOrderTemplate),
+    shippingAddress: {
+      ...shippingAddress,
+      email: 'addr@example.com',
+      state: 'Bavaria',
+      mobile: '0160111222',
+      phone: '022111222',
+    },
+  };
+}
+
+export function getTestOrderWithAttributes(): CommercetoolsOrder {
+  const lineItemWithAttrs: LineItem = {
+    ...lineItem,
+    variant: {
+      id: 1,
+      images: [],
+      sku: 'sku-attr-test',
+      attributes: [
+        { name: 'stringAttr', value: 'hello' },
+        { name: 'numAttr', value: 42 },
+        { name: 'boolAttr', value: true },
+        { name: 'nullAttr', value: null },
+        { name: 'labelAttr', value: { label: 'my label' } },
+        { name: 'scannableCodes', value: '123' },
+        { name: 'emptyAttr', value: '   ' },
+      ],
+    },
+  };
+  return {
+    ...mapTemplateToOrder(commercetoolsOrderTemplate),
+    lineItems: [lineItemWithAttrs],
+  };
+}
+
 function mapTemplateToOrder(template: CommercetoolsOrderTemplate): CommercetoolsOrder {
   return {
     anonymousId: template.anonymousId,

--- a/event/src/order/testModels.ts
+++ b/event/src/order/testModels.ts
@@ -67,6 +67,22 @@ const shippingMethodClickAndCollect: ShippingMethod = {
   active: true,
 };
 
+const shippingMethodUnknown: ShippingMethod = {
+  createdAt: '',
+  id: '',
+  isDefault: false,
+  lastModifiedAt: '',
+  name: 'Unknown',
+  taxCategory: {
+    typeId: 'tax-category',
+    id: '123',
+  },
+  version: 0,
+  zoneRates: [],
+  key: 'unknown_method',
+  active: true,
+};
+
 const price1: CentPrecisionMoney = { type: 'centPrecision', centAmount: 600, currencyCode: 'EUR', fractionDigits: 0 };
 const price2: CentPrecisionMoney = { type: 'centPrecision', centAmount: 0, currencyCode: 'EUR', fractionDigits: 0 };
 
@@ -92,6 +108,21 @@ const shippingInfoClickAndCollect: ShippingInfo = {
     typeId: 'shipping-method',
     id: '123',
     obj: shippingMethodClickAndCollect,
+  },
+  shippingMethodState: '',
+  shippingRate: {
+    price: price2,
+    tiers: [],
+  },
+};
+
+const shippingInfoUnknown: ShippingInfo = {
+  shippingMethodName: 'Unknown',
+  price: price2,
+  shippingMethod: {
+    typeId: 'shipping-method',
+    id: '999',
+    obj: shippingMethodUnknown,
   },
   shippingMethodState: '',
   shippingRate: {
@@ -216,6 +247,15 @@ export function getTestOrderClickAndCollect() {
   return mapTemplateToOrder(template);
 }
 
+export function getTestOrderUnknownServiceType() {
+  const template = commercetoolsOrderTemplate;
+  template.shippingInfo = shippingInfoUnknown;
+  template.lineItems = [lineItem];
+  template.store = undefined;
+  template.custom = undefined;
+  return mapTemplateToOrder(template);
+}
+
 export function getTestOrderClickAndCollectWithMultipleChannels() {
   const template = commercetoolsOrderTemplate;
   template.shippingInfo = shippingInfoClickAndCollect;
@@ -298,6 +338,7 @@ export function getTestOrderWithAttributes(): CommercetoolsOrder {
         { name: 'numAttr', value: 42 },
         { name: 'boolAttr', value: true },
         { name: 'nullAttr', value: null },
+        { name: 'bigintAttr', value: BigInt(7) },
         { name: 'labelAttr', value: { label: 'my label' } },
         { name: 'scannableCodes', value: '123' },
         { name: 'emptyAttr', value: '   ' },

--- a/event/tests/channelService.test.ts
+++ b/event/tests/channelService.test.ts
@@ -135,7 +135,73 @@ describe('ChannelService (event)', () => {
       expect(createFacilityMock).not.toHaveBeenCalled();
       expect(result).toEqual(updatedFacility);
     });
-  });
+
+    it('uses fallback values when address fields are empty strings', async () => {
+      server.use(
+        http.get(ctApi('/channels/:id'), () =>
+          HttpResponse.json({
+            id: 'ch-empty-fields',
+            version: 1,
+            key: 'channel_empty_fields',
+            roles: ['InventorySupply'],
+            createdAt: '',
+            lastModifiedAt: '',
+            address: {
+              streetName: '',
+              streetNumber: '',
+              postalCode: '',
+              city: '',
+              state: '',
+              country: '',
+            },
+          })
+        )
+      );
+      const createdFacility = { id: 'fft-fac-empty', tenantFacilityId: 'channel_empty_fields' };
+      getFacilityIdMock.mockImplementationOnce(() => Promise.resolve(undefined));
+      createFacilityMock.mockImplementationOnce(() => Promise.resolve(createdFacility));
+
+      const result = await channelService.upsertFacility('ch-empty-fields');
+      expect(result).toEqual(createdFacility);
+      expect(createFacilityMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: expect.objectContaining({
+            street: 'not set',
+            houseNumber: '0',
+            postalCode: '00000',
+            city: 'not set',
+            country: 'DE',
+          }),
+        })
+      );
+    });
+
+    it('uses DE as default country when project has no countries', async () => {
+      server.use(
+        http.get(ctApi(''), () =>
+          HttpResponse.json({
+            key: 'test-project',
+            name: 'Test Project',
+            countries: [],
+            currencies: ['EUR'],
+            languages: ['en-US'],
+            version: 1,
+          })
+        )
+      );
+      const createdFacility = { id: 'fft-fac-de', tenantFacilityId: 'channel_01' };
+      getFacilityIdMock.mockImplementationOnce(() => Promise.resolve(undefined));
+      createFacilityMock.mockImplementationOnce(() => Promise.resolve(createdFacility));
+
+      const result = await channelService.upsertFacility('f348e5c2-e2db-4cf3-b254-41220801d2c6');
+      expect(result).toEqual(createdFacility);
+      expect(createFacilityMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: expect.objectContaining({ country: 'DE' }),
+        })
+      );
+    });
+  });  // end upsertFacility
 
   describe('setFacilityOffline', () => {
     it('calls deleteFacility with the tenant facility id and soft-delete flag', async () => {

--- a/event/tests/orderMapper.test.ts
+++ b/event/tests/orderMapper.test.ts
@@ -6,6 +6,7 @@ import {
   getTestOrderClickAndCollectNoChannels,
   getTestOrderClickAndCollectWithCustomField,
   getTestOrderClickAndCollectWithMultipleChannels,
+  getTestOrderUnknownServiceType,
   getTestOrderWithAttributes,
   getTestOrderWithBillingAddress,
   getTestOrderWithCustomField,
@@ -19,6 +20,16 @@ import { StoreService } from 'shared';
 import { server } from 'shared';
 import { getTestClient } from 'shared';
 import { AmbiguousChannelError } from 'shared';
+import {
+  CUSTOM_OBJECT_CONTAINER,
+  CUSTOM_OBJECT_KEY,
+  CUSTOM_TYPE_NAME,
+  ServiceType,
+  ctApi,
+  http,
+  HttpResponse,
+  mockCustomObject,
+} from 'shared';
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
@@ -147,5 +158,43 @@ describe('OrderMapper', () => {
     expect(attrs.find((a) => a.key === 'scannableCodes')).toBeUndefined();
     expect(attrs.find((a) => a.key === 'emptyAttr')).toBeUndefined();
     expect(attrs.find((a) => a.key === 'nullAttr')).toBeUndefined();
+    expect(attrs.find((a) => a.key === 'bigintAttr')).toBeUndefined();
+  });
+
+  it('falls back to plain shipping for a mapped service type that is neither SHIPPING nor CLICK_AND_COLLECT', async () => {
+    server.use(
+      http.get(ctApi(`/custom-objects/${CUSTOM_OBJECT_CONTAINER}/${CUSTOM_OBJECT_KEY}`), () =>
+        HttpResponse.json(
+          mockCustomObject({
+            value: {
+              orderCustomTypeKey: CUSTOM_TYPE_NAME,
+              shippingMethodMapping: { unknown_method: { serviceType: 'SOME_OTHER_TYPE' } },
+            },
+          })
+        )
+      )
+    );
+    const commercetoolsOrder = getTestOrderUnknownServiceType();
+    const fulfillmenttoolsOrder = await orderMapper.mapOrder(commercetoolsOrder);
+    expect(fulfillmenttoolsOrder.deliveryPreferences?.collect).toBeUndefined();
+    expect(fulfillmenttoolsOrder.deliveryPreferences?.shipping?.preselectedFacilities).toEqual([]);
+  });
+
+  it('maps click and collect via line item channel when no collect channel reference field is configured', async () => {
+    server.use(
+      http.get(ctApi(`/custom-objects/${CUSTOM_OBJECT_CONTAINER}/${CUSTOM_OBJECT_KEY}`), () =>
+        HttpResponse.json(
+          mockCustomObject({
+            value: {
+              orderCustomTypeKey: CUSTOM_TYPE_NAME,
+              shippingMethodMapping: { cc: { serviceType: ServiceType.CLICK_AND_COLLECT } },
+            },
+          })
+        )
+      )
+    );
+    const commercetoolsOrder = getTestOrderClickAndCollect();
+    const fulfillmenttoolsOrder = await orderMapper.mapOrder(commercetoolsOrder);
+    expect(fulfillmenttoolsOrder.deliveryPreferences?.collect?.[0].facilityRef).toEqual('store_cologne_fft_id');
   });
 });

--- a/event/tests/orderMapper.test.ts
+++ b/event/tests/orderMapper.test.ts
@@ -6,12 +6,15 @@ import {
   getTestOrderClickAndCollectNoChannels,
   getTestOrderClickAndCollectWithCustomField,
   getTestOrderClickAndCollectWithMultipleChannels,
+  getTestOrderWithAttributes,
+  getTestOrderWithBillingAddress,
   getTestOrderWithCustomField,
   getTestOrderWithDHL,
+  getTestOrderWithFullAddress,
   getTestOrderWithoutOrderNumber,
   getTestOrderWithStore,
 } from '../src/order/testModels';
-import { FftFacilityService } from '@fulfillmenttools/fulfillmenttools-sdk-typescript';
+import { AddressPhoneNumbers, AddressType, FftFacilityService } from '@fulfillmenttools/fulfillmenttools-sdk-typescript';
 import { StoreService } from 'shared';
 import { server } from 'shared';
 import { getTestClient } from 'shared';
@@ -111,5 +114,38 @@ describe('OrderMapper', () => {
     const commercetoolsOrder = getTestOrderClickAndCollectWithCustomField();
     const fulfillmenttoolsOrder = await orderMapper.mapOrder(commercetoolsOrder);
     expect(fulfillmenttoolsOrder.deliveryPreferences?.collect?.[0].facilityRef).toEqual('store_hamburg_fft_id');
+  });
+
+  it('maps billing address as INVOICEADDRESS', async () => {
+    const order = getTestOrderWithBillingAddress();
+    const mapped = await orderMapper.mapOrder(order);
+    expect(mapped.consumer.addresses).toHaveLength(2);
+    const billing = mapped.consumer.addresses.find((a) => a.addressType === AddressType.INVOICEADDRESS);
+    expect(billing).toBeDefined();
+    expect(billing?.city).toEqual('Munich');
+  });
+
+  it('maps address fields email, state, mobile, and phone', async () => {
+    const order = getTestOrderWithFullAddress();
+    const mapped = await orderMapper.mapOrder(order);
+    const addr = mapped.consumer.addresses[0];
+    expect(addr.email).toEqual('addr@example.com');
+    expect(addr.province).toEqual('Bavaria');
+    expect(addr.phoneNumbers).toHaveLength(2);
+    expect(addr.phoneNumbers?.[0].type).toEqual(AddressPhoneNumbers.TypeEnum.MOBILE);
+    expect(addr.phoneNumbers?.[1].type).toEqual(AddressPhoneNumbers.TypeEnum.PHONE);
+  });
+
+  it('maps line item attributes of various types and filters empty/scannableCodes', async () => {
+    const order = getTestOrderWithAttributes();
+    const mapped = await orderMapper.mapOrder(order);
+    const attrs = mapped.orderLineItems[0].article.attributes ?? [];
+    expect(attrs.find((a) => a.key === 'stringAttr')?.value).toEqual('hello');
+    expect(attrs.find((a) => a.key === 'numAttr')?.value).toEqual('42');
+    expect(attrs.find((a) => a.key === 'boolAttr')?.value).toEqual('true');
+    expect(attrs.find((a) => a.key === 'labelAttr')?.value).toEqual('my label');
+    expect(attrs.find((a) => a.key === 'scannableCodes')).toBeUndefined();
+    expect(attrs.find((a) => a.key === 'emptyAttr')).toBeUndefined();
+    expect(attrs.find((a) => a.key === 'nullAttr')).toBeUndefined();
   });
 });

--- a/event/tests/orderProcessor.test.ts
+++ b/event/tests/orderProcessor.test.ts
@@ -28,6 +28,36 @@ describe('OrderProcessor', () => {
       await expect(firstPromise).resolves.not.toThrow();
     });
 
+    it('removes stale order locks that exceed the 60s expiration window', async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      let releaseFirst!: () => void;
+      const findMock = jest.fn();
+      findMock
+        .mockImplementationOnce(
+          () => new Promise((resolve) => (releaseFirst = () => resolve({ id: 'fft-first', version: 1 })))
+        )
+        .mockImplementation(() => Promise.resolve({ id: 'fft-existing', version: 1 }));
+      const mockService = { findByTenantOrderId: findMock, create: jest.fn() } as unknown as FftOrderService;
+      const processor = new OrderProcessor(mockService, orderMapperMock);
+
+      // First call locks the order and hangs while loading from FFT.
+      const firstPromise = processor.processOrder('order-stale');
+
+      // Advance past the 60s lock expiration window.
+      jest.setSystemTime(new Date('2026-01-01T00:01:01.000Z'));
+
+      // Second call runs removeOldLocks(60), which deletes the now-stale lock,
+      // so re-locking the same order does not throw ResourceLockedError.
+      await expect(processor.processOrder('order-stale')).resolves.not.toThrow();
+
+      // Release the still-pending first call so it can settle.
+      releaseFirst();
+      await expect(firstPromise).resolves.not.toThrow();
+      jest.useRealTimers();
+    });
+
     it('skips mapping when the FFT order already exists', async () => {
       // FftOrderServiceMock hardcodes findByTenantOrderId to return undefined, so we use
       // the real FftOrderService here and let MSW return an existing order.


### PR DESCRIPTION
Raises bodyParser limit from 1mb to 5mb to handle large subscription message payloads. Adds unit tests for previously uncovered branches in orderMapper and channelService, bringing branch coverage above 93%.